### PR TITLE
bau: use MetadataCredentialResolver to pick enc. key

### DIFF
--- a/src/main/java/uk/gov/ida/eidas/bridge/factories/VerifyEidasBridgeFactory.java
+++ b/src/main/java/uk/gov/ida/eidas/bridge/factories/VerifyEidasBridgeFactory.java
@@ -195,14 +195,14 @@ public class VerifyEidasBridgeFactory {
                 new XmlObjectToBase64EncodedStringTransformer());
     }
 
-    private VerifyResponseGenerator getVerifyResponseGenerator(String bridgeEntityId, String verifyEntityId) throws KeyStoreException, UnrecoverableKeyException, NoSuchAlgorithmException {
+    private VerifyResponseGenerator getVerifyResponseGenerator(String bridgeEntityId, String verifyEntityId) throws KeyStoreException, UnrecoverableKeyException, NoSuchAlgorithmException, ComponentInitializationException {
         OpenSamlXmlObjectFactory openSamlXmlObjectFactory = new OpenSamlXmlObjectFactory();
 
         AttributeFactory_1_1 attributeFactory_1_1 = new AttributeFactory_1_1(openSamlXmlObjectFactory);
         AssertionSubjectGenerator assertionSubjectGenerator = new AssertionSubjectGenerator(verifyEntityId, openSamlXmlObjectFactory);
         SigningHelper verifySigningHelper = getVerifySigningHelper();
 
-        MetadataBackedEncryptionPublicKeyRetriever metadataBackedEncryptionPublicKeyRetriever = new MetadataBackedEncryptionPublicKeyRetriever(getVerifyMetadataResolver());
+        MetadataBackedEncryptionPublicKeyRetriever metadataBackedEncryptionPublicKeyRetriever = new MetadataBackedEncryptionPublicKeyRetriever(getMetadataCredentialResolver(getVerifyMetadataResolver()));
         EncryptionCredentialFactory encryptionCredentialFactory = new EncryptionCredentialFactory(metadataBackedEncryptionPublicKeyRetriever::retrieveKey);
 
         return new VerifyResponseGenerator(
@@ -284,7 +284,6 @@ public class VerifyEidasBridgeFactory {
         metadataCredentialResolver.initialize();
         return metadataCredentialResolver;
     }
-
 
     private EidasAuthnRequestGenerator getEidasAuthnRequestGenerator() throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException {
         return new EidasAuthnRequestGenerator(configuration.getHostname() + "/metadata", getEidasSigningHelper(), getEidasSingleSignOnServiceLocator());

--- a/src/main/java/uk/gov/ida/eidas/saml/factories/MetadataCredentialResolverFactory.java
+++ b/src/main/java/uk/gov/ida/eidas/saml/factories/MetadataCredentialResolverFactory.java
@@ -1,0 +1,19 @@
+package uk.gov.ida.eidas.saml.factories;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import org.opensaml.saml.metadata.resolver.MetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+
+public class MetadataCredentialResolverFactory {
+    public MetadataCredentialResolver getMetadataCredentialResolver(MetadataResolver metadataResolver) throws ComponentInitializationException {
+        PredicateRoleDescriptorResolver predicateRoleDescriptorResolver = new PredicateRoleDescriptorResolver(metadataResolver);
+        predicateRoleDescriptorResolver.initialize();
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolver();
+        metadataCredentialResolver.setRoleDescriptorResolver(predicateRoleDescriptorResolver);
+        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+        metadataCredentialResolver.initialize();
+        return metadataCredentialResolver;
+    }
+}

--- a/src/test/java/uk/gov/ida/eidas/bridge/helpers/responseToVerify/MetadataBackedEncryptionPublicKeyRetrieverTest.java
+++ b/src/test/java/uk/gov/ida/eidas/bridge/helpers/responseToVerify/MetadataBackedEncryptionPublicKeyRetrieverTest.java
@@ -9,7 +9,9 @@ import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
-import uk.gov.ida.eidas.bridge.helpers.responseToVerify.MetadataBackedEncryptionPublicKeyRetriever;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.security.impl.MetadataCredentialResolver;
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
 
 import java.io.File;
 import java.security.PublicKey;
@@ -22,7 +24,7 @@ public class MetadataBackedEncryptionPublicKeyRetrieverTest {
     @Test
     public void shouldRetrieveKey() throws Exception {
         MetadataResolver metadataResolver = initializeMetadata();
-        MetadataBackedEncryptionPublicKeyRetriever retriever = new MetadataBackedEncryptionPublicKeyRetriever(metadataResolver);
+        MetadataBackedEncryptionPublicKeyRetriever retriever = new MetadataBackedEncryptionPublicKeyRetriever(getMetadataCredentialResolver(metadataResolver));
         PublicKey key = retriever.retrieveKey("https://signin.service.gov.uk");
         assertTrue("Public key should be non-empty", key.getEncoded().length > 10);
     }
@@ -42,5 +44,15 @@ public class MetadataBackedEncryptionPublicKeyRetrieverTest {
         } catch (ResolverException | ComponentInitializationException | InitializationException e) {
             throw propagate(e);
         }
+    }
+
+    private MetadataCredentialResolver getMetadataCredentialResolver(MetadataResolver metadataResolver) throws ComponentInitializationException {
+        PredicateRoleDescriptorResolver predicateRoleDescriptorResolver = new PredicateRoleDescriptorResolver(metadataResolver);
+        predicateRoleDescriptorResolver.initialize();
+        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolver();
+        metadataCredentialResolver.setRoleDescriptorResolver(predicateRoleDescriptorResolver);
+        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
+        metadataCredentialResolver.initialize();
+        return metadataCredentialResolver;
     }
 }

--- a/src/test/java/uk/gov/ida/eidas/bridge/helpers/responseToVerify/MetadataBackedEncryptionPublicKeyRetrieverTest.java
+++ b/src/test/java/uk/gov/ida/eidas/bridge/helpers/responseToVerify/MetadataBackedEncryptionPublicKeyRetrieverTest.java
@@ -9,9 +9,8 @@ import org.opensaml.core.config.InitializationException;
 import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
 import org.opensaml.saml.security.impl.MetadataCredentialResolver;
-import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import uk.gov.ida.eidas.saml.factories.MetadataCredentialResolverFactory;
 
 import java.io.File;
 import java.security.PublicKey;
@@ -20,6 +19,8 @@ import static com.google.common.base.Throwables.propagate;
 import static org.junit.Assert.assertTrue;
 
 public class MetadataBackedEncryptionPublicKeyRetrieverTest {
+
+    private final MetadataCredentialResolverFactory metadataCredentialResolverFactory = new MetadataCredentialResolverFactory();
 
     @Test
     public void shouldRetrieveKey() throws Exception {
@@ -47,12 +48,6 @@ public class MetadataBackedEncryptionPublicKeyRetrieverTest {
     }
 
     private MetadataCredentialResolver getMetadataCredentialResolver(MetadataResolver metadataResolver) throws ComponentInitializationException {
-        PredicateRoleDescriptorResolver predicateRoleDescriptorResolver = new PredicateRoleDescriptorResolver(metadataResolver);
-        predicateRoleDescriptorResolver.initialize();
-        MetadataCredentialResolver metadataCredentialResolver = new MetadataCredentialResolver();
-        metadataCredentialResolver.setRoleDescriptorResolver(predicateRoleDescriptorResolver);
-        metadataCredentialResolver.setKeyInfoCredentialResolver(DefaultSecurityConfigurationBootstrap.buildBasicInlineKeyInfoCredentialResolver());
-        metadataCredentialResolver.initialize();
-        return metadataCredentialResolver;
+        return metadataCredentialResolverFactory.getMetadataCredentialResolver(metadataResolver);
     }
 }


### PR DESCRIPTION
This uses the opensaml 'way' to retrieve the encrpytion public key from
metadata. In order to minimise changes to our saml libs I have kept have
not changed any other classes interfaces which means that our Retriever
object will retrieve a Credential then extract the public key and return it
where it will be wrapped in a new Credential by the calling object.